### PR TITLE
[BOJ] 11047 : 동전 0

### DIFF
--- a/gibeom/23-04-26.py
+++ b/gibeom/23-04-26.py
@@ -1,0 +1,16 @@
+from sys import stdin
+
+n, k = map(int, stdin.readline().split())
+coins = [int(stdin.readline()) for _ in range(n)]
+
+cnt = 0
+for coin in coins[::-1]:
+    cnt += k // coin
+    k %= coin
+
+print(cnt)
+
+##########################
+#    memory: 31256KB     #
+#    time:   44ms        #
+##########################


### PR DESCRIPTION
https://www.acmicpc.net/problem/11047

오늘 넘 피곤해서 쉬운걸로 감잡기,,ㅎ
동전을 오름차순으로 입력받기 때문에 내림차순으로 순회하면서 `k`를 나눠주면 최소 동전 개수를 구할 수 있다.
동전이 `k`보다 가치가 크더라도  `k // coin = 0`, `k % coin = k`이므로 `cnt`와 `k`에 영향을 주지 않는다.