### PR TITLE
[BOJ] 4963 : 섬의 개수 (23.04.27)

### DIFF
--- a/gibeom/23-04-27.py
+++ b/gibeom/23-04-27.py
@@ -1,0 +1,39 @@
+from sys import stdin, setrecursionlimit
+
+
+def dfs(height, width):
+    land[height][width] = 0
+
+    for d in direction:
+        nh, nw = height + d[0], width + d[1]
+        if is_out_of_range(nh, nw) or not land[nh][nw]:
+            continue
+        
+        dfs(nh, nw)
+
+
+def is_out_of_range(height, width):
+    return height < 0 or width < 0 or height >= h or width >= w
+
+
+setrecursionlimit(10**6)
+while True:
+    w, h = map(int, stdin.readline().split())
+    if w == h == 0:
+        break
+
+    land = [list(map(int, stdin.readline().split())) for _ in range(h)]
+
+    direction = [(1, 0), (0, -1), (-1, 0), (0, 1), (-1, -1), (-1, 1), (1, -1), (1, 1)]
+    cnt = 0
+    for height in range(h):
+        for width in range(w):
+            if land[height][width]:
+                dfs(height, width)
+                cnt += 1
+    print(cnt)
+
+##########################
+#    memory: 31588KB     #
+#    time:   80ms        #
+##########################


### PR DESCRIPTION
https://www.acmicpc.net/problem/4963

`dfs(height, width)`
- 방문한 땅일 경우 0을 할당하여 다시 방문하지 않도록 한다.
- 상하좌우, 대각선 4방향을 순회하면서 범위 안이거나 땅인 경우만 깊이 우선 탐색 실시한다.
<br>

`main`
- 백준의 최대 재귀 깊이는 1,000이므로  `setrecursionlimit()` 메서드로 재귀 깊이를 늘려준다.
- 이중 for문으로 순회하면서 땅일 경우 `dfs()`를 호출하고 cnt를 1 증가시킨다.