### PR TITLE
[BOJ] 12865 : 평범한 배낭

### DIFF
--- a/gibeom/23-05-03.py
+++ b/gibeom/23-05-03.py
@@ -1,0 +1,42 @@
+from sys import stdin
+
+# 1
+n, k = map(int, stdin.readline().split())
+bag = [(0, 0)] + [tuple(map(int, stdin.readline().split())) for _ in range(n)]
+
+dp = [[0] * (k + 1) for _ in range(n + 1)]
+for i in range(1, n + 1):
+    w, v = bag[i]
+    for j in range(1, k + 1):
+        if j < w:
+            dp[i][j] = dp[i - 1][j]
+        else:
+            dp[i][j] = max(dp[i - 1][j], v + dp[i - 1][j - w])
+
+print(dp[n][k])
+
+##########################
+#    memory: 227172KB    #
+#    time:   4688ms      #
+##########################
+
+
+# 2
+n, k = map(int, stdin.readline().split())
+bag = [tuple(map(int, stdin.readline().split())) for _ in range(n)]
+bag.sort(reverse=True)
+
+dp = {0: 0}
+for w, v in bag:
+    tmp = {}
+    for value, weight in dp.items():
+        if (w_sum := w + weight) < dp.get(v_sum := v + value, k + 1):
+            tmp[v_sum] = w_sum
+    dp.update(tmp)
+
+print(max(dp.keys()))
+
+##########################
+#    memory: 34744KB     #
+#    time:   448ms       #
+##########################


### PR DESCRIPTION
https://www.acmicpc.net/problem/12865

꽤나 어려웠던 dp문제,, 두 풀이는 메모리 사용량과 시간이 확연히 차이나는 것을 볼 수 있다.

첫 번째 풀이는 `(n + 1) * (k + 1)` 크기의 2차원 list를 사용하고, 두 번째 for문을 봤을 때 1부터 k까지 순회한다.
두 번째 풀이는 k 이하를 만들 수 있는 무게 조합만 나오고 해당 무게 조합이 dp의 무게보다 작아야만 dp에 저장된다. 그 후 dp를 순회한다. 이 때문에 차이가 나타난다.

효율적인 방법을 항상 고민하기.
