### PR TITLE
[BOJ] 2512 : 예산 (23.05.04)

### DIFF
--- a/gibeom/23-05-04.py
+++ b/gibeom/23-05-04.py
@@ -1,0 +1,29 @@
+from sys import stdin
+
+
+def binary_search(start, end):
+    while start <= end:
+        limit = (start + end) // 2
+        total_budget = 0
+        for b in budget:
+            total_budget += b if b < limit else limit
+        
+        if total_budget <= m:
+            start = limit + 1
+        else:
+            end = limit - 1
+    return end
+
+
+n = int(stdin.readline())
+budget = list(map(int, stdin.readline().split()))
+m = int(stdin.readline())
+
+budget.sort()
+start, end = 1, budget[-1]
+print(binary_search(start, end))
+
+##########################
+#    memory: 32276KB     #
+#    time:   48ms        #
+##########################


### PR DESCRIPTION
https://www.acmicpc.net/problem/2512

상한액을 이진 탐색으로 찾는다.
- budget 리스트를 순회하면서 상한액보다 작으면 해당 budget을 더하고, 크면 상한액을 더한다.
- 더한 값이 총 예산(`m`)보다 같거나 작은지 확인한다. 이에 따라 start와 end를 조정한다.

처음에 start를 budget의 최솟값으로 설정했는데 47%에서 실패했다. budget의 최솟값이 m보다 큰 경우도 있기 때문이다. 이 때는 budget 리스트의 모든 요소를 상한액으로 배정해야 한다. 따라서 start를 1로 설정