### PR TITLE
[BOJ] 1300 : K번째 수 (23.05.05)

### DIFF
--- a/gibeom/23-05-05.py
+++ b/gibeom/23-05-05.py
@@ -1,0 +1,31 @@
+from sys import stdin
+
+
+def get_cnt(mid):
+    cnt = 0
+    for i in range(1, n + 1):
+        cnt += min(mid // i, n)
+
+    return cnt
+
+
+def binary_search(start, end):
+    while start <= end:
+        mid = (start + end) // 2
+
+        if get_cnt(mid) < k:
+            start = mid + 1
+        else:
+            end = mid - 1
+
+    return start
+
+
+n, k = int(stdin.readline()), int(stdin.readline())
+
+print(binary_search(1, k))
+
+##########################
+#    memory: 31256KB     #
+#    time:   672ms       #
+##########################


### PR DESCRIPTION
https://www.acmicpc.net/problem/1300

배열 B는 1 ~ N^2까지다. 하지만 N이 최대 10^5이므로 10^10까지 계산하고 배열을 만드는 것은 공간, 시간복잡도에서 초과가 발생할 것이라 생각했다.
그렇다면 k번째 수를 어떻게 찾는지가 관건. 이진 탐색을 하면서 mid 값보다 작거나 같은 수의 개수를 계산한다. 해당 개수를 `k`와 비교한다.

`get_cnt()`
- `mid`보다 작거나 같은 값의 개수를 구하는 메서드
- `i`는 A 배열에서 `i`번째 행을 의미한다.
- `mid`에서 `i`로 나눈 몫을 구하면 `i`번째 행에서 `mid`보다 작거나 같은 수의 개수를 구할 수 있다.
- 배열은 N x N이므로 `mid // i`가 N을 초과하면 안된다. 따라서 두 값 중 최솟값을 리턴한다.
<br>

`binary_search()`
- `k`번째 수는 `k`를 초과하는 값을 가질 수 없다. 따라서 end 값을 `k`로 두어 범위를 줄인다.
- 이진 탐색하여 `mid`를 구하고 `mid` 이하의 개수를 계산한다. -> `get_cnt()`
- `k`와 비교해서 start와 end 범위를 좁힌다.