### PR TITLE
[BOJ] 14889 : 스타트와 링크 (23.05.09)

### DIFF
--- a/gibeom/23-05-09.py
+++ b/gibeom/23-05-09.py
@@ -1,0 +1,53 @@
+from sys import stdin
+from itertools import combinations
+
+
+# 1
+def get_team_stat(team):
+    team_stat = 0
+    for member in combinations(team, 2):
+        team_stat += s[member[0]][member[1]] + s[member[1]][member[0]]
+
+    return team_stat
+
+
+n = int(stdin.readline())
+s = [list(map(int, stdin.readline().split())) for _ in range(n)]
+
+members = set(range(n))
+comb = list(combinations(members, n // 2))
+case_cnt = len(comb) // 2
+res = 1e9
+for start_team in comb:
+    if case_cnt == 0:
+        break
+
+    case_cnt -= 1
+    link_team = tuple(members - set(start_team))
+    res = min(res, abs(get_team_stat(start_team) - get_team_stat(link_team)))
+
+print(res)
+
+##########################
+#    memory: 56392KB     #
+#    time:   1260ms      #
+##########################
+
+
+# 2
+n = int(stdin.readline())
+s = [list(map(int, stdin.readline().split())) for _ in range(n)]
+
+member_stat = [sum(i) + sum(j) for i, j in zip(s, zip(*s))]
+total_stat = sum(member_stat) // 2
+
+res = 1e9
+for c in combinations(member_stat[:-1], n // 2):
+    res = min(res, abs(total_stat - sum(c)))
+
+print(res)
+
+##########################
+#    memory: 31256KB     #
+#    time:   96ms        #
+##########################


### PR DESCRIPTION
https://www.acmicpc.net/problem/14889

### 1번 풀이
조합이 떠올라서 백트래킹이 아닌 조합으로 해결
- 조합 중에서 절반만 돌아야 중복으로 순회하지 않기 때문에 `case_cnt`를 계산해둔다.
- `link_team`은 `start_team`에 속하지 않은 사람이므로 set의 차집합으로 구한다.
  - 조합의 경우의 수에 `link_team`도 포함되는데 여기서 미리 로직을 수행하기 때문에 `case_cnt`를 설정한 것
- `get_team_stat()` 메서드로 각 팀의 능력치를 구하고 두 팀의 능력치의 차이를 계산한다.
<br>

### 2번 풀이
다른 사람의 소요 시간과 비교했는데 10배 이상이 차이났다. 하지만 코드가 도저히 이해되지 않았고 나랑 비슷한 사람이 있을까 싶어 게시판을 뒤적였다.
https://www.acmicpc.net/board/view/72643 에서 해설을 찾았다. 풀이법을 이해하고 나니까 기가 막히다고 생각했다. 어떻게 이런 생각을 하지?

- 행렬 `s`가 있을 때 `zip(*s)`를 사용하면 `s`의 전치행렬을 구할 수 있다. 기억해두면 나중에 유용하게 쓸 듯?