### PR TITLE
[BOJ]  14499 : 주사위 굴리기 (23.05.17)

### DIFF
--- a/gibeom/23-05-17.py
+++ b/gibeom/23-05-17.py
@@ -1,0 +1,49 @@
+from sys import stdin
+from collections import deque
+
+
+def turn(command):
+    global dice
+
+    top, north, east, west, south, bottom = dice
+    if command == 1:
+        dice = [west, north, top, bottom, south, east]
+    elif command == 2:
+        dice = [east, north, bottom, top, south, west]
+    elif command == 3:
+        dice = [south, top, east, west, bottom, north]
+    else:
+        dice = [north, bottom, east, west, top, south]
+
+
+def is_out_of_range(r, c):
+    return r < 0 or r >= n or c < 0 or c >= m
+
+
+n, m, x, y, k = map(int, stdin.readline().split())
+maps = [list(map(int, stdin.readline().split())) for _ in range(n)]
+commands = deque(map(int, stdin.readline().split()))
+
+direction = [(0, 1), (0, -1), (-1, 0), (1, 0)]
+dice = [0, 0, 0, 0, 0, 0]
+while commands:
+    command = commands.popleft()
+    nx, ny = x + direction[command - 1][0], y + direction[command - 1][1]
+    if is_out_of_range(nx, ny):
+        continue
+
+    x, y = nx, ny
+    turn(command)
+
+    if maps[x][y] == 0:
+        maps[x][y] = dice[5]
+    else:
+        dice[5] = maps[x][y]
+        maps[x][y] = 0
+
+    print(dice[0])
+
+##########################
+#    memory: 34216KB     #
+#    time:   64ms        #
+##########################


### PR DESCRIPTION
https://www.acmicpc.net/problem/14499

주사위를 어떻게 굴릴지 고민을 많이 했던 문제. 이것만 해결하면 금방 풀리는 문제였다
``` python
from sys import stdin
from collections import deque


# 주사위 굴리기
def turn(command):
    global dice

    top, north, east, west, south, bottom = dice
    if command == 1: # 동쪽으로 굴리기
        dice = [west, north, top, bottom, south, east]
    elif command == 2: # 서쪽으로 굴리기
        dice = [east, north, bottom, top, south, west]
    elif command == 3: # 북쪽으로 굴리기
        dice = [south, top, east, west, bottom, north]
    else: # 남쪽으로 굴리기
        dice = [north, bottom, east, west, top, south]


# 범위를 벗어났는지 확인
def is_out_of_range(r, c):
    return r < 0 or r >= n or c < 0 or c >= m


n, m, x, y, k = map(int, stdin.readline().split())
maps = [list(map(int, stdin.readline().split())) for _ in range(n)]
commands = deque(map(int, stdin.readline().split()))

direction = [(0, 1), (0, -1), (-1, 0), (1, 0)]
dice = [0, 0, 0, 0, 0, 0]
while commands:
    command = commands.popleft() # 명령어 하나 꺼내기
    nx, ny = x + direction[command - 1][0], y + direction[command - 1][1] # 다음 x, y 좌표
    if is_out_of_range(nx, ny): # 범위를 벗어났으면 이동하지 않고 건너뛰기
        continue

    x, y = nx, ny # 좌표 이동
    turn(command) # 주사위 굴리기

    if maps[x][y] == 0: # 지도에 쓰여 있는 수가 0이면 주사위 바닥면을 복사
        maps[x][y] = dice[5]
    else: # 0이 아니면 지도에 쓰여 있는 수를 복사하고 0으로 변경
        dice[5] = maps[x][y]
        maps[x][y] = 0

    print(dice[0]) # 주사위의 윗 면에 쓰여 있는 수 출력
```