### PR TITLE
[BOJ] 14500 : 테트리미노 (23.05.21)

### DIFF
--- a/gibeom/23-05-21.py
+++ b/gibeom/23-05-21.py
@@ -1,0 +1,49 @@
+from sys import stdin
+
+
+def dfs(depth, total, r, c):
+    global visited, res
+
+    if res >= total + (4 - depth) * max_num:
+        return
+
+    if depth == 4:
+        res = max(res, total)
+        return
+
+    for i in range(4):
+        nr, nc = r + direction[i], c + direction[3 - i]
+        if is_out_of_range(nr, nc) or visited[nr][nc]:
+            continue
+        if depth == 2:
+            visited[nr][nc] = True
+            dfs(depth + 1, total + board[nr][nc], r, c)
+            visited[nr][nc] = False
+        visited[nr][nc] = True
+        dfs(depth + 1, total + board[nr][nc], nr, nc)
+        visited[nr][nc] = False
+
+
+def is_out_of_range(r, c):
+    return r < 0 or r >= n or c < 0 or c >= m
+
+
+n, m = map(int, stdin.readline().split())
+board = [list(map(int, stdin.readline().split())) for _ in range(n)]
+
+visited = [[False] * m for _ in range(n)]
+direction = [1, 0, -1, 0]
+res = 0
+max_num = max(map(max, board))
+for r in range(n):
+    for c in range(m):
+        visited[r][c] = True
+        dfs(1, board[r][c], r, c)
+        visited[r][c] = False
+
+print(res)
+
+##########################
+#    memory: 38008KB     #
+#    time:   176ms       #
+##########################


### PR DESCRIPTION
https://www.acmicpc.net/problem/14500

### 첫 번째 풀이
``` python
from sys import stdin


# ㅗ, ㅏ, ㅓ, ㅜ을 제외한 나머지 테트리미노 dfs 탐색
def dfs(depth, total, r, c):
    global visited, res
    if res >= total + (4 - depth) * max_num: # 현재 depth에서 board의 최댓값(max_num)을 채워도 res에 못 미칠 경우
        return

    if depth == 4: # 폴리오미노 4개를 모두 탐색했을 경우 리턴
        res = max(res, total)
        return
    
    for i in range(4): # r, c 좌표의 상하좌우 탐색
        nr, nc = r + direction[i], c + direction[3 - i] # 다음 폴리오미노
        if is_out_of_range(nr, nc) or visited[nr][nc]: # 범위를 벗어났거나 이미 방문했을 경우
            continue

        visited[nr][nc] = True # 방문 처리
        dfs(depth + 1, total + board[nr][nc], nr, nc)
        visited[nr][nc] = False # 같은 폴리오미노를 탐색하는 경우가 있으므로 방문 처리 취소


# ㅗ, ㅏ, ㅓ, ㅜ 모양 탐색
def tetromino(r, c):
    global res

    next_polyomino = []
    for i in range(4): # r, c 좌표의 상하좌우 탐색
        nr, nc = r + direction[i], c + direction[3 - i] # 다음 폴리오미노
        if is_out_of_range(nr, nc): # 범위를 벗어났을 경우
            continue

        next_polyomino.append(board[nr][nc]) # 다음 폴리오미노 추가
    
    if len(next_polyomino) == 3: # 다음 폴리오미노가 3개일 경우
        res = max(res, sum(next_polyomino) + board[r][c])  # 현재 r, c 좌표 값 + 다음 폴리오미노의 합과 res 중 최댓값
    elif len(next_polyomino) == 4: # 다음 폴리오미노가 4개일 경우
        for i in range(4):
            total = board[r][c]
            for j in range(3):
                total += next_polyomino[(i + j) % 4] # index 012, 123, 230, 301 -> ㅗ, ㅏ, ㅓ, ㅜ 모양의 합 구하기
            res = max(res, total)


def is_out_of_range(r, c):
    return r < 0 or r >= n or c < 0 or c >= m


n, m = map(int, stdin.readline().split())
board = [list(map(int, stdin.readline().split())) for _ in range(n)]

visited = [[False] * m for _ in range(n)]
direction = [1, 0, -1, 0]
res = 0
max_num = max(map(max, board)) # board의 요소 중 최댓값
for r in range(n):
    for c in range(m):
        visited[r][c] = True
        dfs(1, board[r][c], r, c)
        tetromino(r, c)
        visited[r][c] = False

print(res)
```
`dfs()`에서 `if res >= total + (4 - depth) * max_num` 조건을 제외하면 **6515ms**가 소요되었고 추가한 위 코드는 **848ms**가 소요되었다.
`ㅗ, ㅏ, ㅓ, ㅜ`를 구하는 메서드를 따로 구현하지 않고 `dfs()`에서 한 번에 탐색할 수 있어서 다시 시도
<br>

### 두 번째 풀이
``` python
from sys import stdin


# 테트리미노 dfs 탐색
def dfs(depth, total, r, c):
    global visited, res

    if res >= total + (4 - depth) * max_num: # 현재 depth에서 board의 최댓값(max_num)을 채워도 res에 못 미칠 경우
        return

    if depth == 4: # 폴리오미노 4개를 모두 탐색했을 경우 리턴
        res = max(res, total)
        return

    for i in range(4):  # r, c 좌표의 상하좌우 탐색
        nr, nc = r + direction[i], c + direction[3 - i] # 다음 폴리오미노
        if is_out_of_range(nr, nc) or visited[nr][nc]: # 범위를 벗어났거나 이미 방문했을 경우
            continue
        if depth == 2: # 현재 폴리오미노를 두 개 선택했을 경우
            visited[nr][nc] = True
            dfs(depth + 1, total + board[nr][nc], r, c) # 3번째 폴리오미노를 더하고 현재 r, c 좌표로 다시 dfs 탐색
            visited[nr][nc] = False
        visited[nr][nc] = True
        dfs(depth + 1, total + board[nr][nc], nr, nc)
        visited[nr][nc] = False


def is_out_of_range(r, c):
    return r < 0 or r >= n or c < 0 or c >= m


n, m = map(int, stdin.readline().split())
board = [list(map(int, stdin.readline().split())) for _ in range(n)]

visited = [[False] * m for _ in range(n)]
direction = [1, 0, -1, 0]
res = 0
max_num = max(map(max, board))
for r in range(n):
    for c in range(m):
        visited[r][c] = True
        dfs(1, board[r][c], r, c)
        visited[r][c] = False

print(res)
```
`dfs()`에서 아래 if문을 타면 `ㅗ, ㅏ, ㅓ, ㅜ` 테트리미노를 구할 수 있다.
``` python
if depth == 2:
    visited[nr][nc] = True
    dfs(depth + 1, total + board[nr][nc], r, c)
    visited[nr][nc] = False
```
현재 `□□`일 때 nr, nc의 좌표를 선택한 것이 `□□□`일 경우 r, c로 다시 dfs()를 호출하면  `□■□`의 색칠된 폴리오미노에서 다음 폴리오미노를 탐색한다. 따라서  `ㅗ, ㅏ, ㅓ, ㅜ` 모양을 탐색할 수 있게 된다.
중복 탐색이 많이 줄어서 **176ms** 소요