### PR TITLE
[BOJ] 14891 : 톱니바퀴 (23.05.27)

### DIFF
--- a/gibeom/23-05-27.py
+++ b/gibeom/23-05-27.py
@@ -1,0 +1,43 @@
+from sys import stdin
+from collections import deque
+
+
+def dfs(now, d):
+    global visited
+
+    if visited[now] == cnt:
+        return
+    
+    visited[now] = cnt
+    left = gears[now][6]
+    right = gears[now][2]
+
+    if now - 1 >= 0 and left != gears[now - 1][2]:
+        dfs(now - 1, d * -1)
+        
+    if now + 1 < 4 and right != gears[now + 1][6]:
+        dfs(now + 1, d * -1)
+    
+    if d == 1:
+        gears[now].appendleft(gears[now].pop())
+    else:
+        gears[now].append(gears[now].popleft())
+
+
+gears = [deque(stdin.readline().rstrip()) for _ in range(4)]
+k = int(stdin.readline())
+
+visited = [-1] * 4
+cnt = 0
+while cnt < k:
+    now, d = map(int, stdin.readline().split())
+    dfs(now - 1, d)
+    cnt += 1
+
+res = sum(1 << i if gears[i][0] == '1' else 0 for i in range(4))
+print(res)
+
+##########################
+#    memory: 34140KB     #
+#    time:   64ms        #
+##########################


### PR DESCRIPTION
https://www.acmicpc.net/problem/14891

``` python
from sys import stdin
from collections import deque


def dfs(now, d):
    global visited

    if visited[now] == cnt: # 현재 회전 횟수에 이미 방문했으면 리턴
        return
    
    visited[now] = cnt
    left = gears[now][6] # 현재 톱니바퀴의 왼쪽 극
    right = gears[now][2] # 현재 톱니바퀴의 오른쪽 극

    if now - 1 >= 0 and left != gears[now - 1][2]: # 다음 톱니바퀴의 오른쪽 극과 다르면 dfs
        dfs(now - 1, d * -1)
        
    if now + 1 < 4 and right != gears[now + 1][6]: # 다음 톱니바퀴의 왼쪽 극과 다르면 dfs
        dfs(now + 1, d * -1)
    
    if d == 1:
        gears[now].appendleft(gears[now].pop()) # 시계 방향 회전
    else:
        gears[now].append(gears[now].popleft()) # 반시계 방향 회전


gears = [deque(stdin.readline().rstrip()) for _ in range(4)]
k = int(stdin.readline())

visited = [-1] * 4
cnt = 0 # 회전 횟수
while cnt < k:
    now, d = map(int, stdin.readline().split()) # 회전시킨 톱니바퀴 번호, 방향
    dfs(now - 1, d)
    cnt += 1

res = sum(1 << i if gears[i][0] == '1' else 0 for i in range(4)) # 톱니바퀴 12시 방향이 S극이면 왼쪽으로 shift
print(res)
```
톱니바퀴(gear)는 `[1, 0, 1, 0, 1, 1, 1, 1]` 식으로 주어지고, 12시 방향부터 시계 방향으로 주어진다. 따라서
- 0번 index : 12시 방향
- 2번 index : 3시 방향 `right`
- 6번 index : 9시 방향 `left`
- 시계 방향 회전 : 7번 index 값이 0번 index로 이동
- 반시계 방향 회전 : 0번 index 값이 7번 index로 이동

회전할 때 삽입, 삭제가 양쪽에서 이루어지기 때문에 deque를 사용했다.
