### PR TITLE
[BOJ] 15683 : 감시 (23.05.29)

### DIFF
--- a/gibeom/23-05-29.py
+++ b/gibeom/23-05-29.py
@@ -1,0 +1,73 @@
+from sys import stdin
+
+
+def dfs(office, idx):
+    global res
+
+    if idx >= len(cctv):
+        blind_spot = sum(o.count(0) for o in office)
+        res = min(res, blind_spot)
+        return
+
+    r, c = cctv[idx]
+    if office[r][c] == 1:
+        for i in range(4):
+            tmp_office = [o[:] for o in office]
+            watch(tmp_office, r, c, direction[i][0], direction[i][1])
+            dfs(tmp_office, idx + 1)
+    elif office[r][c] == 2:
+        for i in range(2):
+            tmp_office = [o[:] for o in office]
+            watch(tmp_office, r, c, direction[i][0], direction[i][1])
+            watch(tmp_office, r, c, -direction[i][0], -direction[i][1])
+            dfs(tmp_office, idx + 1)
+    elif office[r][c] == 3:
+        for i in range(4):
+            tmp_office = [o[:] for o in office]
+            watch(tmp_office, r, c, direction[i][0], direction[i][1])
+            watch(tmp_office, r, c, direction[(i + 1) % 4][0], direction[(i + 1) % 4][1])
+            dfs(tmp_office, idx + 1)
+    elif office[r][c] == 4:
+        for i in range(4):
+            tmp_office = [o[:] for o in office]
+            watch(tmp_office, r, c, direction[i][0], direction[i][1])
+            watch(tmp_office, r, c, direction[(i + 1) % 4][0], direction[(i + 1) % 4][1])
+            watch(tmp_office, r, c, direction[(i + 2) % 4][0], direction[(i + 2) % 4][1])
+            dfs(tmp_office, idx + 1)
+    else:
+        for i in range(4):
+            watch(office, r, c, direction[i][0], direction[i][1])
+        dfs(office, idx + 1)
+
+
+def watch(office, r, c, dr, dc):
+    while True:
+        r += dr
+        c += dc
+        if r < 0 or r >= n or c < 0 or c >= m or office[r][c] == 6:
+            break
+
+        if office[r][c] == 0:
+            office[r][c] = '#'
+
+
+n, m = map(int, stdin.readline().split())
+office = []
+cctv = []
+for i in range(n):
+    o = list(map(int, stdin.readline().split()))
+    for j in range(m):
+        if 0 < o[j] < 6:
+            cctv.append((i, j))
+    office.append(o)
+
+res = 1e9
+direction = [(0, 1), (1, 0), (0, -1), (-1, 0)]
+dfs(office, 0)
+
+print(res)
+
+##########################
+#    memory: 31256KB     #
+#    time:   344ms       #
+##########################


### PR DESCRIPTION
https://www.acmicpc.net/problem/15683

``` python
from sys import stdin


def dfs(office, idx):
    global res

    if idx >= len(cctv): # 모든 cctv를 탐색했을 경우
        blind_spot = sum(o.count(0) for o in office) # 사각 지대 크기 (0의 개수)
        res = min(res, blind_spot) # 최솟값 갱신
        return

    r, c = cctv[idx]
    if office[r][c] == 1: # 1번 cctv
        for i in range(4): # 90도로 회전하면 경우의 수 4개
            tmp_office = [o[:] for o in office] # deep copy
            watch(tmp_office, r, c, direction[i][0], direction[i][1]) # 감시 영역 표시
            dfs(tmp_office, idx + 1) # 다음 cctv dfs 탐색
    elif office[r][c] == 2: # 2번 cctv
        for i in range(2): # 90도로 회전하면 경우의 수 2개
            tmp_office = [o[:] for o in office]
            watch(tmp_office, r, c, direction[i][0], direction[i][1])
            watch(tmp_office, r, c, -direction[i][0], -direction[i][1])
            dfs(tmp_office, idx + 1)
    elif office[r][c] == 3: # 3번 cctv
        for i in range(4): # 90도로 회전하면 경우의 수 4개
            tmp_office = [o[:] for o in office]
            watch(tmp_office, r, c, direction[i][0], direction[i][1])
            watch(tmp_office, r, c, direction[(i + 1) % 4][0], direction[(i + 1) % 4][1])
            dfs(tmp_office, idx + 1)
    elif office[r][c] == 4: # 4번 cctv
        for i in range(4): # 90도로 회전하면 경우의 수 4개
            tmp_office = [o[:] for o in office]
            watch(tmp_office, r, c, direction[i][0], direction[i][1])
            watch(tmp_office, r, c, direction[(i + 1) % 4][0], direction[(i + 1) % 4][1])
            watch(tmp_office, r, c, direction[(i + 2) % 4][0], direction[(i + 2) % 4][1])
            dfs(tmp_office, idx + 1)
    else: # 5번 cctv
        for i in range(4): # 90도로 회전하면 경우의 수 1개, 네 방향 감시 영역 표시하고 dfs 한 번만 호출
            watch(office, r, c, direction[i][0], direction[i][1])
        dfs(office, idx + 1)


# 감시 영역 표시
def watch(office, r, c, dr, dc):
    while True:
        r += dr
        c += dc
        if r < 0 or r >= n or c < 0 or c >= m or office[r][c] == 6: # 범위를 벗어났거나 벽(6)일 경우 while문 탈출
            break

        if office[r][c] == 0: # 빈 칸이면 '#'으로 감시 영역 표시
            office[r][c] = '#'


n, m = map(int, stdin.readline().split())
office = []
cctv = []
for i in range(n):
    o = list(map(int, stdin.readline().split()))
    for j in range(m):
        if 0 < o[j] < 6:
            cctv.append((i, j)) # cctv 좌표 삽입
    office.append(o)

res = 1e9
direction = [(0, 1), (1, 0), (0, -1), (-1, 0)]
dfs(office, 0)

print(res)
```
cctv 종류마다 90도 회전 시 경우의 수가 다르기 때문에 if문으로 분기했다
for문에서 경우의 수를 하나씩 확인하면서 `watch()`로 감시 영역을 표시하고 `dfs()`를 호출한다. 이 때 같은 `office`를 사용하면 감시 영역을 덮어쓰기 때문에 경우의 수마다 `office`를 복사해서 사용한다.