### PR TITLE
[BOJ] 16926 : 배열 돌리기 1 (23.06.07)

### DIFF
--- a/gibeom/23-06-07.py
+++ b/gibeom/23-06-07.py
@@ -1,0 +1,58 @@
+from sys import stdin
+
+
+def is_out_of_range(r, c, r_end, c_end, start):
+    return r < start or r > r_end or c < start or c > c_end
+
+
+def move(r, c, d, r_end, c_end, start):
+    if is_out_of_range(r + direction[d][0], c + direction[d][1], r_end, c_end, start):
+        d = (d + 1) % 4
+    return r + direction[d][0], c + direction[d][1], d
+
+
+N, M, R = map(int, stdin.readline().split())
+arr = [list(stdin.readline().split()) for _ in range(N)]
+res = [[None] * M for _ in range(N)]
+
+direction = [(1, 0), (0, 1), (-1, 0), (0, -1)]
+for i in range(min(N, M) // 2):
+    r_len, c_len = N - 1 - i * 2, M - 1 - i * 2
+
+    element_cnt = (r_len + c_len) * 2
+    turn_cnt = R % element_cnt
+
+    r, c = i, i
+    if turn_cnt < element_cnt // 2:
+        if turn_cnt < r_len:
+            r += turn_cnt
+            d = 0
+        else:
+            r += r_len
+            c += turn_cnt - r_len
+            d = 1
+    else:
+        turn_cnt -= element_cnt // 2
+        if turn_cnt < r_len:
+            r += r_len - turn_cnt
+            c += c_len
+            d = 2
+        else:
+            c += c_len - (turn_cnt - r_len)
+            d = 3
+
+    nr, nc, nd = i, i, 0
+    while element_cnt:
+        res[r][c] = arr[nr][nc]
+        r, c, d = move(r, c, d, i + r_len, i + c_len, i)
+        nr, nc, nd = move(nr, nc, nd, i + r_len, i + c_len, i)
+
+        element_cnt -= 1
+
+for re in res:
+    print(*re)
+
+##########################
+#    memory: 37168KB     #
+#    time:   196ms       #
+##########################


### PR DESCRIPTION
https://www.acmicpc.net/problem/16926

각 계층끼리 반시계방향으로 돌기 때문에 껍질 까듯이 계층마다 for문으로 순회했다.
N, M은 최대 300이고 계층의 개수는 `min(N, M) // 2`이므로 150, 각 계층마다 순회하는 요소의 개수는 달라지지만 최댓값인 `N * M`으로만 계산하면 시간복잡도는 `O((min(N, M) // 2) * N * M)`으로 13,500,000이다. 시간 제한 1초 내에 가능하고 실제로는 이것보다 적게 걸린다.
``` python
from sys import stdin


### 범위를 벗어났는지 확인
def is_out_of_range(r, c, r_end, c_end, start):
    return r < start or r > r_end or c < start or c > c_end


### 좌표 이동
def move(r, c, d, r_end, c_end, start):
    if is_out_of_range(r + direction[d][0], c + direction[d][1], r_end, c_end, start):
        d = (d + 1) % 4 # direction의 index
    return r + direction[d][0], c + direction[d][1], d


N, M, R = map(int, stdin.readline().split())
arr = [list(stdin.readline().split()) for _ in range(N)]
res = [[None] * M for _ in range(N)] ### 배열을 돌린 결과를 담을 2차원 리스트

direction = [(1, 0), (0, 1), (-1, 0), (0, -1)]
for i in range(min(N, M) // 2): # 각 계층 순회
    r_len, c_len = N - 1 - i * 2, M - 1 - i * 2 # row의 길이, col의 길이

    element_cnt = (r_len + c_len) * 2 # 각 계층의 총 요소 개수
    turn_cnt = R % element_cnt # 회전 횟수를 총 요소 개수로 나눈 나머지 -> 반복 회전 제거

    r, c = i, i # 각 계층의 시작 좌표
    if turn_cnt < element_cnt // 2: # 이 if-else는 회전 후 시작 좌표가 어디에 위치하는지 찾는다.
        if turn_cnt < r_len: # 아래 방향에 있을 때
            r += turn_cnt
            d = 0 # direction의 index
        else: # 오른쪽 방향에 있을 때
            r += r_len
            c += turn_cnt - r_len
            d = 1
    else:
        turn_cnt -= element_cnt // 2
        if turn_cnt < r_len: # 위 방향에 있을 때
            r += r_len - turn_cnt
            c += c_len
            d = 2
        else: # 왼쪽 방향에 있을 때
            c += c_len - (turn_cnt - r_len)
            d = 3

    nr, nc, nd = i, i, 0
    while element_cnt: # 계층의 요소 개수만큼 순회
        res[r][c] = arr[nr][nc] # r, c를 찾았으면 시작 좌표부터 순회하면서 res에 삽입한다.
        r, c, d = move(r, c, d, i + r_len, i + c_len, i)
        nr, nc, nd = move(nr, nc, nd, i + r_len, i + c_len, i)

        element_cnt -= 1

for re in res:
    print(*re)
```
<br>

![image](https://github.com/co-niverse/algorithm-study/assets/101033262/dc13466c-ae54-4d45-a3b8-fecb12505b29)
색칠한 칸이 반시계 방향으로 함께 회전하는 하나의 계층이고, 각 계층마다 시작 좌표는 `(i, i)`이다.

이 계층에서 각 칸에 있는 수는 `turn_cnt`와 시작 좌표가 그만큼 회전했을 때 위치하는 좌표이다.
- row의 길이 : `r_len = 3`
- col의 길이 : `c_len = 3`
- 총 요소의 개수 : `element_cnt = 12`

if-else문을 거치면 회전 후 좌표`(r, c)`를 구할 수 있다.
이후 while문에서 시작 좌표`(nr, nc)`의 값부터 `(r, c)`에 삽입하면서 이동한다.