### PR TITLE
[23-06-19] BOJ 11724

### DIFF
--- a/yoonjin/0619/11724.py
+++ b/yoonjin/0619/11724.py
@@ -1,0 +1,26 @@
+import sys
+sys.setrecursionlimit(5000)
+input = sys.stdin.readline
+
+def dfs(v):
+    visited[v] = True
+    for e in graph[v]:
+        if not visited[e]:
+            dfs(e)
+    
+n,m = map(int, input().split())
+graph = [[] for _ in range(n+1)]
+visited = [False] * (n+1)
+count = 0
+
+for i in range(m):
+    u, v = map(int, input().split())
+    graph[u].append(v)
+    graph[v].append(u)
+
+for j in range(1, n+1):
+    if not visited[j]:
+        dfs(j)
+        count += 1
+
+print(count)


### PR DESCRIPTION
# 문제
[11724](https://www.acmicpc.net/problem/11724)

## 해결 과정
``` python
import sys
sys.setrecursionlimit(5000)
input = sys.stdin.readline

# dfs 구현
def dfs(v):
    visited[v] = True
    for e in graph[v]:
        if not visited[e]:
            dfs(e)
    
# 입력 받기
n,m = map(int, input().split())
graph = [[] for _ in range(n+1)]
visited = [False] * (n+1)
count = 0

for i in range(m):
    u, v = map(int, input().split())
    # 양방향으로 인접리스트에 추가
    graph[u].append(v)
    graph[v].append(u)

for j in range(1, n+1):
    # 방문처리 안된 경우 dfs하고 count 증가
    if not visited[j]:
        dfs(j)
        count += 1

print(count)
```

## 메모리, 시간
- 65148KB
- 680ms


## 회고
- setrecursionlimit 함수를 사용했는데도 계속 시간 초과가 떴다.
- input = sys.stdin.readline 을 작성하니까 통과가 되었는데, input 정의해주는걸 어떤 상황에서 해야되는지는 잘모르겠다 ..

## 알게된 것
dfs 문제에서 인접리스트를 사용해서 풀고, 양방향으로 append를 대칭으로 해줘야하는 것을 알게되었다.
