### PR TITLE
[BOJ] 1987 : 알파벳 (23.06.23)

### DIFF
--- a/gibeom/23-06-23.py
+++ b/gibeom/23-06-23.py
@@ -1,0 +1,33 @@
+from sys import stdin
+
+
+def dfs(r, c, now_cnt):
+    global max_cnt
+
+    if alphabet[board[r][c]]:
+        max_cnt = max(max_cnt, now_cnt)
+        return
+
+    alphabet[board[r][c]] = True
+    for i in range(4):
+        nr, nc = r + direction[i], c + direction[3 - i]
+        if 0 <= nr < R and 0 <= nc < C:
+            dfs(nr, nc, now_cnt + 1)
+    alphabet[board[r][c]] = False
+
+
+R, C = map(int, stdin.readline().split())
+board = [list(map(lambda x: ord(x) - 65, stdin.readline().rstrip())) for _ in range(R)]
+
+alphabet = [False] * 26
+direction = [1, 0, -1, 0]
+max_cnt = 0
+dfs(0, 0, 0)
+
+print(max_cnt)
+
+##########################
+#    PyPy3               #
+#    memory: 166452KB    #
+#    time:   5720ms      #
+##########################


### PR DESCRIPTION
# 문제
#76 

## 해결 과정
``` python
from sys import stdin


def dfs(r, c, now_cnt):
    global max_cnt

    if alphabet[board[r][c]]: # 지나온 알파벳일 경우 최대 칸 수를 갱신하고 리턴
        max_cnt = max(max_cnt, now_cnt)
        return

    alphabet[board[r][c]] = True # 방문 체크
    for i in range(4): # 상하좌우 순회
        nr, nc = r + direction[i], c + direction[3 - i] # 다음 칸
        if 0 <= nr < R and 0 <= nc < C: # 범위 내일 경우 dfs 탐색
            dfs(nr, nc, now_cnt + 1)
    alphabet[board[r][c]] = False # 방문 체크 해제


R, C = map(int, stdin.readline().split())
board = [list(map(lambda x: ord(x) - 65, stdin.readline().rstrip())) for _ in range(R)] # 알파벳을 0 ~ 25의 숫자로 변경하여 저장

alphabet = [False] * 26 # 지나온 알파벳 확인용 리스트
direction = [1, 0, -1, 0]
max_cnt = 0
dfs(0, 0, 0)

print(max_cnt)
```

## 메모리, 시간
PyPy3
- 166452KB
- 5720ms

## 회고
시간 초과가 계속 나서 애를 먹었다. 찾아보니까 dfs로 풀었을 경우 `PyPy3`로 제출해야 하고, bfs로 풀었을 경우 `Python3`로 제출해도 된다고 한다