### PR TITLE
[BOJ] 20055 : 컨베이어 벨트 위의 로봇 (23.06.26)

### DIFF
--- a/gibeom/23-06-26.py
+++ b/gibeom/23-06-26.py
@@ -1,0 +1,37 @@
+from sys import stdin
+from collections import deque
+
+
+def decrease(idx):
+    global durability
+    robot[idx] = True
+    belt[idx] -= 1
+    if belt[idx] == 0:
+        durability += 1
+
+
+n, k = map(int, stdin.readline().split())
+belt = deque(map(int, stdin.readline().split()))
+robot = deque([False] * n)
+step, durability = 0, 0
+while durability < k:
+    belt.rotate()
+    robot.rotate()
+    robot[0] = False
+
+    robot[-1] = False
+    for i in range(n - 2, -1, -1):
+        if not robot[i + 1] and robot[i] and belt[i + 1] > 0:
+            robot[i] = False
+            decrease(i + 1)
+
+    if belt[0] > 0:
+        decrease(0)
+    step += 1
+
+print(step)
+
+##########################
+#    memory: 34140KB     #
+#    time:   2908ms      #
+##########################


### PR DESCRIPTION
# 문제
#79

## 해결 과정
``` python
from sys import stdin
from collections import deque


# 내구도 감소하기
def decrease(idx):
    global durability
    robot[idx] = True
    belt[idx] -= 1 # 내구도 감소
    if belt[idx] == 0: # 내구도가 0이면 durability 1 증가
        durability += 1


n, k = map(int, stdin.readline().split())
belt = deque(map(int, stdin.readline().split()))
robot = deque([False] * n)
step, durability = 0, 0
while durability < k:
    belt.rotate() # 벨트 회전
    robot.rotate() # 로봇 회전
    robot[0] = False # 회전하기전 마지막 index가 True인 경우때문에 False 처리

    robot[-1] = False # 로봇 이동 -> 마지막 index는 내리는 위치이므로 False 처리
    for i in range(n - 2, -1, -1):
        if not robot[i + 1] and robot[i] and belt[i + 1] > 0: # 앞 index에 로봇이 없으면서 내구도가 있고, 현재 index에 로봇이 있으면
            robot[i] = False
            decrease(i + 1)

    if belt[0] > 0: # 올리는 위치에 내구도가 있으면
        decrease(0)
    step += 1

print(step)
```

## 메모리, 시간
- 34140KB
- 2908ms

## 회고
11일 전에 풀었을 떄랑 로직이 거의 같은데 시간은 왜 두배나 차이가 날까.. #58

## 알게 된 것
deque의 `rotate(k)`에서 k의 기본값은 1이며 deque의 모든 요소를 k만큼 오른쪽으로 이동, k가 음수일 경우 왼쪽으로 이동시킨다.
시간 복잡도는 `O(k)`이다


