### PR TITLE
[BOJ] 14888 : 연산자 끼워넣기 (23.06.27)

### DIFF
--- a/gibeom/23-06-27.py
+++ b/gibeom/23-06-27.py
@@ -1,0 +1,40 @@
+from sys import stdin
+
+
+def dfs(res, idx):
+    global max_res, min_res
+
+    if idx == n:
+        max_res = max(max_res, res)
+        min_res = min(min_res, res)
+        return
+
+    for i in range(4):
+        if operators[i] > 0:
+            operators[i] -= 1
+            if i == 0:
+                dfs(res + nums[idx], idx + 1)
+            elif i == 1:
+                dfs(res - nums[idx], idx + 1)
+            elif i == 2:
+                dfs(res * nums[idx], idx + 1)
+            else:
+                dfs(int(res / nums[idx]), idx + 1)
+            operators[i] += 1
+
+
+n = int(stdin.readline())
+nums = list(map(int, stdin.readline().split()))
+operators = list(map(int, stdin.readline().split()))
+
+max_res = int(-1e9)
+min_res = int(1e9)
+dfs(nums[0], 1)
+
+print(max_res)
+print(min_res)
+
+##########################
+#    memory: 31256KB     #
+#    time:   76ms        #
+##########################


### PR DESCRIPTION
# 문제
#83

## 해결 과정
``` python
from sys import stdin


def dfs(res, idx):
    global max_res, min_res

    if idx == n: # 숫자를 모두 탐색했을 경우 최댓값, 최솟값을 갱신하고 리턴
        max_res = max(max_res, res)
        min_res = min(min_res, res)
        return

    for i in range(4):
        if operators[i] > 0: # 연산자가 있을 때
            operators[i] -= 1
            if i == 0: # + 연산자
                dfs(res + nums[idx], idx + 1)
            elif i == 1: # - 연산자
                dfs(res - nums[idx], idx + 1)
            elif i == 2: # * 연산자
                dfs(res * nums[idx], idx + 1)
            else: # / 연산자
                dfs(int(res / nums[idx]), idx + 1) # res가 음수일 수 있기 떄문에 // 는 사용불가
            operators[i] += 1


n = int(stdin.readline())
nums = list(map(int, stdin.readline().split()))
operators = list(map(int, stdin.readline().split()))

max_res = int(-1e9) # 결과는 -10억보다 크거나 같음
min_res = int(1e9) # 결과는 10억보다 작거나 같음
dfs(nums[0], 1)

print(max_res)
print(min_res)
```

## 메모리, 시간
- 31256KB
- 76ms

## 알게 된 것
`max_res`, `min_res`를 -1e9, 1e9로 초기화했었는데 계속 틀렸다. 출력해 보니까 `1000000000.0`으로 소수점이 찍혀있었다. res가 10억이더라도 `1000000000.0`을 선택해서 틀렸다고 생각했고, `int()`로 소수점을 제거하니까 통과! 
