### PR TITLE
[BOJ] 1967 : 트리의 지름 (23.06.28)

### DIFF
--- a/gibeom/23-06-28.py
+++ b/gibeom/23-06-28.py
@@ -1,0 +1,33 @@
+from sys import stdin, setrecursionlimit
+
+
+def dfs(now):
+    for next, weight in tree[now]:
+        if distance[next] != -1:
+            continue
+        distance[next] = distance[now] + weight
+        dfs(next)
+
+
+setrecursionlimit(10**6)
+n = int(stdin.readline())
+tree = [[] for _ in range(n)]
+for _ in range(n - 1):
+    a, b, w = map(int, stdin.readline().split())
+    tree[a - 1].append((b - 1, w))
+    tree[b - 1].append((a - 1, w))
+
+distance = [-1] * n
+distance[0] = 0
+dfs(0)
+max_node = distance.index(max(distance))
+
+distance = [-1] * n
+distance[max_node] = 0
+dfs(max_node)
+print(max(distance))
+
+##########################
+#    memory: 35572KB     #
+#    time:   76ms        #
+##########################


### PR DESCRIPTION
# 문제
#87 

## 해결 과정
``` python
from sys import stdin, setrecursionlimit


# 각 노드까지의 길이 dfs 탐색
def dfs(now):
    for next, weight in tree[now]:
        if distance[next] != -1: # 방문한 노드는 건너뜀
            continue
        distance[next] = distance[now] + weight # 길이 갱신
        dfs(next)


setrecursionlimit(10**6)
n = int(stdin.readline())
tree = [[] for _ in range(n)]
for _ in range(n - 1):
    a, b, w = map(int, stdin.readline().split())
    tree[a - 1].append((b - 1, w))
    tree[b - 1].append((a - 1, w))

distance = [-1] * n
distance[0] = 0
dfs(0) # 루트 노드에서 각 노드까지의 길이 탐색
max_node = distance.index(max(distance)) # 루트 노드에서 가장 먼 노드

distance = [-1] * n
distance[max_node] = 0
dfs(max_node) # 가장 먼 노드에서 각 노드까지의 길이 탐색
print(max(distance))
```
어느 한 노드에서 가장 먼 노드 `A`를 찾고 `A`노드에서 가장 먼 노드 `B`를 찾으면, `A`에서 `B`까지의 거리가 트리의 지름이 된다.

## 메모리, 시간
- 35572KB
- 76ms

## 회고
이전에 풀었었던 https://www.acmicpc.net/problem/1167 문제와 매우 유사해서 쉽게 풀었다

