### PR TITLE
[BOJ] 17825 : 주사위 윷놀이 (23.07.07)

### DIFF
--- a/gibeom/23-07-07.py
+++ b/gibeom/23-07-07.py
@@ -1,0 +1,59 @@
+from sys import stdin
+
+
+def dfs(i, record):
+    global max_record
+
+    if i == 10:
+        max_record = max(max_record, record)
+        return
+    elif record + 40 * (10 - i) < max_record:
+        return
+
+    now_dice = dices[i]
+    for k in range(4):
+        if arrived[k]:
+            continue
+
+        tmp = [players[k][0], players[k][1]]
+        r, c = players[k][0], players[k][1] + now_dice
+        if len(board[r]) - 1 < c:
+            players[k][0], players[k][1] = r, c
+            arrived[k] = True
+            dfs(i + 1, record)
+            arrived[k] = False
+            players[k][0], players[k][1] = tmp
+            continue
+
+        if board[r][c] == 40:
+            r, c = 4, 0
+        elif r == 0 and board[r][c] % 10 == 0:
+            r, c = board[r][c] // 10, 0
+        elif 0 < r < 4 and board[r][c] % 5 == 0:
+            r, c = 5, board[r][c] // 5 - 5
+
+        if [r, c] not in players:
+            players[k][0], players[k][1] = r, c
+            dfs(i + 1, record + board[r][c])
+            players[k][0], players[k][1] = tmp
+
+
+board = [[i for i in range(0, 41, 2)]]
+board.append([10, 13, 16, 19, 25, 30, 35, 40])
+board.append([20, 22, 24, 25, 30, 35, 40])
+board.append([30, 28, 27, 26, 25, 30, 35, 40])
+board.append([40])
+board.append([25, 30, 35, 40])
+
+dices = list(map(int, stdin.readline().split()))
+players = [[0, 0] for _ in range(4)]
+arrived = [False] * 4
+max_record = 0
+dfs(0, 0)
+
+print(max_record)
+
+##########################
+#    memory: 31256KB     #
+#    time:   72ms        #
+##########################


### PR DESCRIPTION
# 문제
#107

## 해결 과정
``` python
from sys import stdin


def dfs(i, record):
    global max_record

    if i == 10: # 주사위를 모두 굴렸을 때
        max_record = max(max_record, record) # 점수 최댓값 갱신
        return
    elif record + 40 * (10 - i) < max_record: # 백트래킹
        return # 남은 주사위 횟수를 모두 굴렸을 때 전부 40점이어도 최댓값보다 작을 경우 주사위를 더 이상 굴리지 않는다

    now_dice = dices[i] # 현재 주사위에서 나온 수
    for k in range(4): # 말 순회
        if arrived[k]: # 이미 도착한 말일 경우
            continue

        tmp = [players[k][0], players[k][1]]
        r, c = players[k][0], players[k][1] + now_dice # 주사위 수만큼 전진
        if len(board[r]) - 1 < c: # 말이 게임판을 나갔을 경우 (도착점 이상의 r, c)
            players[k][0], players[k][1] = r, c
            arrived[k] = True # 도착한 말 체크
            dfs(i + 1, record) #  도착한 말은 점수 없음
            arrived[k] = False
            players[k][0], players[k][1] = tmp
            continue

        if board[r][c] == 40: # 말이 위치한 칸의 숫자가 40일 경우
            r, c = 4, 0
        elif r == 0 and board[r][c] % 10 == 0: # 0번 row이고 게임판 값이 10의 배수일 경우
            r, c = board[r][c] // 10, 0
        elif 0 < r < 4 and board[r][c] % 5 == 0: # 1 ~ 3번 row이고 게임판 값이 5의 배수일 경우
            r, c = 5, board[r][c] // 5 - 5

        if [r, c] not in players: # 이동한 칸에 다른 말이 없을 경우
            players[k][0], players[k][1] = r, c
            dfs(i + 1, record + board[r][c])
            players[k][0], players[k][1] = tmp


board = [[i for i in range(0, 41, 2)]]
board.append([10, 13, 16, 19, 25, 30, 35, 40])
board.append([20, 22, 24, 25, 30, 35, 40])
board.append([30, 28, 27, 26, 25, 30, 35, 40])
board.append([40])
board.append([25, 30, 35, 40])

dices = list(map(int, stdin.readline().split()))
players = [[0, 0] for _ in range(4)] # 4개의 말 (r, c)
arrived = [False] * 4 # 도착 여부
max_record = 0
dfs(0, 0)

print(max_record)
```
<img width="617" alt="image" src="https://github.com/co-niverse/algorithm-study/assets/101033262/82fa17d8-a164-43e6-872a-f222979d5173">

게임판을 위와 같이 설정하고 dfs 탐색했다. **색칠한 부분**은 게임판에서 공통된 칸이고, 이 칸들을 핸들링하는 것이 중요하다. 이를 따로 두고 하면 이동할 칸에 이미 있는 말을 체크할 수 없다
ex) 1번 말이 `(1, 4)`에 있고 2번 말이 `(2, 3)`에 있을 때 이를 합쳐주지 않을 경우 25점인 같은 칸에 있음에도 불구하고 다른 칸으로 인식됨

각 row는 다음과 같다
- row 0
<img src="https://github.com/co-niverse/algorithm-study/assets/101033262/b5a859ed-720b-4273-90eb-eb911359c9c4" width=400 height=400>
10, 20, 30에 말이 놓이지 않았을 때 이동하는 칸

- row 1
<img src="https://github.com/co-niverse/algorithm-study/assets/101033262/b01489ae-8057-4460-a877-1b1abc4a495c" width=400 height=400>
10에 말이 놓였을 때 이동하는 칸

- row 2
<img src="https://github.com/co-niverse/algorithm-study/assets/101033262/74b3d903-f27b-425c-a111-6e09e672e647" width=400 height=400>
20에 말이 놓였을 떄 이동하는 칸

- row 3
<img src="https://github.com/co-niverse/algorithm-study/assets/101033262/10416042-623c-43e3-8810-8d86fae837a4" width=400 height=400>
30에 말이 놓였을 때 이동하는 칸

- row 4
row 0, 1, 2, 3, 5의 공통된 칸

- row 5
row 1, 2, 3의 공통된 칸

#### 공통된 칸으로 이동했을 때 합쳐주기
- `board[r][c] == 40`:
40은 0, 1, 2, 3, 5번 row의 공통 칸에 해당 -> `(4, 0)`으로 이동

- `r == 0`일 때 `board[r][c] == 10 or 20 or 30`:
0번 row의 10의 배수만 공통 칸에 해당 -> `(10으로 나눈 몫, 0)`으로 이동
- `r == 1 or 2 or 3`일 때 `board[r][c] == 25 or 30 or 35`:
1, 2, 3번 row의 5의 배수만 공통 칸에 해당 -> `(5, 5로 나눈 몫 - 5)`으로 이동
<br>

참고로 이러한 브루트포스 문제를 dfs로 풀 때 백트래킹을 설정하지 않으면 시간이 오래 걸린다
남은 depth를 최댓값으로 채워도 갱신할 수 없으면 해당 dfs는 max가 될 수 없다 따라서 남은 depth를 탐색하지 않고 리턴해준다
``` python
elif record + 40 * (10 - i) < max_record:
    return
```
백트래킹을 설정하는 위의 코드가 없으면 544ms가 소요된다

## 메모리, 시간
- 31256KB
- 72ms

##  회고
처음에 0번 row의 10, 20, 30, 40만 공통 칸으로 처리했다가 삽질을 오래 했다. 뒤늦게 1, 2, 3번 row의 25, 30, 35, 40도 공통 칸으로 처리해야 한다는 것을 알아차렸고 `board`를 수정해서 다시 분기 처리했다
사람마다 초기 `board` 설정을 어떻게 하냐에 따라 로직이 달라질 것 같다