### PR TITLE
[23-07-10] BOJ (1946)

### DIFF
--- a/yoonjin/0710/1946.py
+++ b/yoonjin/0710/1946.py
@@ -1,0 +1,63 @@
+## 1차(시간초과)
+import sys
+input = sys.stdin.readline
+T = int(input())
+for i in range(T):
+  num = int(input())
+  score = []
+  answer = 0
+  for j in range(num):
+    write, speak = map(int, input().split())
+    score.append((write, speak))
+  for write_t, speak_t in score:
+    count = 0
+    for l in range(num):
+      if (write_t > score[l][0]) and (speak_t > score[l][1]):
+        break
+      else:
+        count += 1
+    if count == num:
+      answer += 1
+  print(answer)
+
+## 2차(시간초과)
+import sys
+input = sys.stdin.readline
+T = int(input())
+for i in range(T):
+  num = int(input())
+  write_score = []
+  speak_score = []
+  answer = 0
+  for j in range(num):
+    write, speak = map(int, input().split())
+    write_score.append(write)
+    speak_score.append(speak)
+  for k in range(num):
+    write_t = write_score[k]
+    speak_t = speak_score[k]
+    if (write_t == max(write_score)) and (speak_t == max(speak_score)):
+      continue
+    else:
+      answer += 1
+  print(answer)
+
+
+## 최종
+import sys
+input = sys.stdin.readline
+T = int(input())
+for i in range(T):
+    num = int(input())
+    score = []
+    for j in range(num):
+        write, speak = map(int, input().split())
+        score.append((write, speak))
+    score.sort()
+    hired = 1
+    man = score[0][1]
+    for j in range(1,num):
+      if score[j][1] < man:
+        man = score[j][1]
+        hired += 1
+    print(hired)


### PR DESCRIPTION
# 문제
#113 

## 해결 과정
``` python
## 1차(시간초과)
import sys
input = sys.stdin.readline
T = int(input())
for i in range(T):
  num = int(input())
  score = []
  answer = 0
  for j in range(num):
    write, speak = map(int, input().split())
    score.append((write, speak))
  for write_t, speak_t in score:
    count = 0
    for l in range(num):
      if (write_t > score[l][0]) and (speak_t > score[l][1]):
        break
      else:
        count += 1
    if count == num:
      answer += 1
  print(answer)

## 2차(시간초과)
import sys
input = sys.stdin.readline
T = int(input())
for i in range(T):
  num = int(input())
  write_score = []
  speak_score = []
  answer = 0
  for j in range(num):
    write, speak = map(int, input().split())
    write_score.append(write)
    speak_score.append(speak)
  for k in range(num):
    write_t = write_score[k]
    speak_t = speak_score[k]
    if (write_t == max(write_score)) and (speak_t == max(speak_score)):
      continue
    else:
      answer += 1
  print(answer)
```
시간 초과 남
``` python
## 최종
import sys
input = sys.stdin.readline
T = int(input())
for i in range(T):
    num = int(input())
    score = []
    for j in range(num):
        write, speak = map(int, input().split())
        score.append((write, speak))
    score.sort() # 정렬
    hired = 1 # 서류 기준 1등은 무조건 채용
    man = score[0][1] # 서류 1등의 면접 등수 저장
    for j in range(1,num):
      if score[j][1] < man: # 면접 등수가 더 낮으면 조건 통과하니까 채용
        man = score[j][1] # 면접 등수 갱신 -> 이전 값들을 비교할 필요 없음 = 어짜피 다 비교해야 하는데 이전에 이미 비교한거니까!
        hired += 1
    print(hired)
```

## 메모리, 시간
*백준 문제일 경우 아래에 입력해주세요*
- 44716KB
- 3360ms

## 회고
첫번째 풀이에서 시간 초과가 나서, for문을 하나 줄여서 두번째 풀이로 풀었는데도 시간 초과가 났다.
max를 구하는 과정이 for문 처럼 시간이 많이 걸려서 그런 것 같다.

그래서 다른 사람들 풀이를 참고한 결과 정렬을 한 이후에, 서류 기준으로 정렬한 이후 면접만 비교하면 된다.
면접을 비교할 때도 가장 높았던 등수를 저장해나가면서 그거랑만 비교하면 된다.

스스로 생각해내기엔 쫌 어려웠다 ~