### PR TITLE
[BOJ] 21758 : 꿀 따기

### DIFF
--- a/gibeom/23-07-15.py
+++ b/gibeom/23-07-15.py
@@ -1,0 +1,32 @@
+from sys import stdin
+
+
+def fly():
+    honey_amount = 0
+    for i in range(1, n - 1):
+        bee_1 = accum_honey[n - 1] - honey[i] - honey[0]
+        bee_2 = accum_honey[n - 1] - accum_honey[i]
+        honey_amount = max(honey_amount, bee_1 + bee_2)
+
+        bee_1 = accum_honey[i] - honey[0]
+        bee_2 = accum_honey[n - 2] - accum_honey[i - 1]
+        honey_amount = max(honey_amount, bee_1 + bee_2)
+
+        bee_1 = accum_honey[i - 1]
+        bee_2 = accum_honey[n - 2] - honey[i]
+        honey_amount = max(honey_amount, bee_1 + bee_2)
+    return honey_amount
+
+
+n = int(stdin.readline())
+honey = list(map(int, stdin.readline().split()))
+accum_honey = honey[:]
+for i in range(1, n):
+    accum_honey[i] += accum_honey[i - 1]
+
+print(fly())
+
+##########################
+#    memory: 42340KB     #
+#    time:   172ms       #
+##########################


### PR DESCRIPTION
# 문제
#132

## 해결 과정
``` python
from sys import stdin


def fly():
    honey_amount = 0
    for i in range(1, n - 1):
        # 벌1, 벌2, 벌통 순서이고 벌1은 0번 index, 벌통은 n - 1번 index에 고정, 벌2만 움직이면서 최댓값 확인
        bee_1 = accum_honey[n - 1] - honey[i] - honey[0] # 꿀 총합에서 벌1, 벌2 시작 위치 빼기
        bee_2 = accum_honey[n - 1] - accum_honey[i] # 꿀 총합에서 벌2 시작 위치까지의 누적합 빼기
        honey_amount = max(honey_amount, bee_1 + bee_2)

        # 벌1, 벌통, 벌2 순서이고 벌1은 0번 index, 벌2은 n - 1번 index에 고정, 벌통만 움직이면서 최댓값 확인
        bee_1 = accum_honey[i] - honey[0] # 벌통까지의 누적합에서 벌1 시작 위치 빼기
        bee_2 = accum_honey[n - 2] - accum_honey[i - 1] # 2번 벌은 n - 1에 있기 떄문에 n - 2까지의 누적합에서 벌통 전까지의 누적합 빼기
        honey_amount = max(honey_amount, bee_1 + bee_2)

        # 벌통, 벌1, 벌2 순서이고 벌통은 0번 index, 벌2은 n - 1번 index에 고정, 벌1만 움직이면서 최댓값 확인
        bee_1 = accum_honey[i - 1] # 벌1 시작 위치 전까지의 누적합
        bee_2 = accum_honey[n - 2] - honey[i] # n - 2까지의 누적합에서 벌1 시작 위치 뺴기
        honey_amount = max(honey_amount, bee_1 + bee_2)
    return honey_amount


n = int(stdin.readline())
honey = list(map(int, stdin.readline().split()))
accum_honey = honey[:] 
for i in range(1, n): # 꿀 누적합 구하기
    accum_honey[i] += accum_honey[i - 1]

print(fly())
```

## 메모리, 시간
- 42340KB
- 172ms

## 회고
누적합이 떠올라서 미리 누적합을 구해서 풀었다 서브태스크가 있어서 재미있었다!