### PR TITLE
[BOJ] 14728 : 벼락치기 (23.07.27)

### DIFF
--- a/gibeom/23-07-27.py
+++ b/gibeom/23-07-27.py
@@ -1,0 +1,16 @@
+from sys import stdin
+
+n, t = map(int, stdin.readline().split())
+dp = [0] * (t + 1)
+
+for _ in range(n):
+    k, s = map(int, stdin.readline().split())
+    for i in range(t, k - 1, -1):
+        dp[i] = max(dp[i], dp[i - k] + s)
+
+print(dp[t])
+
+##########################
+#    memory: 31256KB     #
+#    time:   368ms       #
+##########################


### PR DESCRIPTION
# 문제
#162

## 해결 과정
``` python
from sys import stdin

n, t = map(int, stdin.readline().split()) # 단원 개수, 총 공부시간
dp = [0] * (t + 1)

for _ in range(n):
    k, s = map(int, stdin.readline().split()) # 예상 공부시간, 배점
    for i in range(t, k - 1, -1): # t부터 k까지 역순으로 순회
        dp[i] = max(dp[i], dp[i - k] + s) # 현재 index의 배점과 i - k번째 index 배점에 s을 더한 값 중 최댓값

print(dp[t])
```
역순으로 순회하기 떄문에 `i - k`index는 아직 k가 반영되지 않은 배점이다. 따라서 s를 더해도 중복 계산이 되지 않는다
## 메모리, 시간
- 31256KB
- 368ms
