### PR TITLE
[BOJ] 9251 : LCS (23.08.01)

### DIFF
--- a/gibeom/23-08-01.py
+++ b/gibeom/23-08-01.py
@@ -1,0 +1,38 @@
+from sys import stdin
+
+# 1
+letter_1 = stdin.readline().rstrip()
+letter_2 = stdin.readline().rstrip()
+dp = [[0] * (len(letter_2) + 1) for _ in range(len(letter_1) + 1)]
+for i in range(1, len(letter_1) + 1):
+    for j in range(1, len(letter_2) + 1):
+        if letter_1[i - 1] == letter_2[j - 1]:
+            dp[i][j] = dp[i - 1][j - 1] + 1
+        else:
+            dp[i][j] = max(dp[i][j - 1], dp[i - 1][j])
+print(dp[-1][-1])
+
+##########################
+#    memory: 55712KB     #
+#    time:   580ms       #
+##########################
+
+
+# 2
+letter_1 = stdin.readline().rstrip()
+letter_2 = stdin.readline().rstrip()
+dp = [0] * len(letter_2)
+for let_1 in letter_1:
+    cnt = 0
+    for i, let_2 in enumerate(letter_2):
+        if dp[i] > cnt:
+            cnt = dp[i]
+        elif let_1 == let_2:
+            dp[i] = cnt + 1
+
+print(max(dp))
+
+##########################
+#    memory: 31256KB     #
+#    time:   212ms       #
+##########################


### PR DESCRIPTION
# 문제
#170

## 해결 과정
### 1.
``` python
from sys import stdin

letter_1 = stdin.readline().rstrip()
letter_2 = stdin.readline().rstrip()
dp = [[0] * (len(letter_2) + 1) for _ in range(len(letter_1) + 1)] # 2차원 리스트
for i in range(1, len(letter_1) + 1):
    for j in range(1, len(letter_2) + 1):
        if letter_1[i - 1] == letter_2[j - 1]: # 두 문자가 같으면
            dp[i][j] = dp[i - 1][j - 1] + 1 # 1번, 2번 문자가 추가되기 전의 dp 값 + 1
        else: # 두 문자가 다르면
            dp[i][j] = max(dp[i][j - 1], dp[i - 1][j]) # 1번 문자가 추가되기 전의 dp 값과 2번 문자가 추가되기 전의 dp 값 중 최댓값
print(dp[-1][-1])
```
https://velog.io/@emplam27/%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EA%B7%B8%EB%A6%BC%EC%9C%BC%EB%A1%9C-%EC%95%8C%EC%95%84%EB%B3%B4%EB%8A%94-LCS-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-Longest-Common-Substring%EC%99%80-Longest-Common-Subsequence
쉽게 설명되어 있으니 참고 바람!
<br>

### 2.
``` python
from sys import stdin

letter_1 = stdin.readline().rstrip()
letter_2 = stdin.readline().rstrip()
dp = [0] * len(letter_2) # 1차원 리스트
for let_1 in letter_1: # 문자 하나마다 2번 문자 전부 대입
    cnt = 0
    for i, let_2 in enumerate(letter_2):
        if dp[i] > cnt: # 현재 dp값이 cnt보다 크면
            cnt = dp[i]
        elif let_1 == let_2: # 두 문자가 같으면
            dp[i] = cnt + 1

print(max(dp))
```

## 메모리, 시간
- 31256KB
- 212ms

## 회고
그림그리면서 하면 금방 푸는 것 같다
두 풀이의 시간 복잡도는 `O(n^2)`인데 결과는 2번 풀이가 두 배이상 빨랐다