### PR TITLE
[BOJ] 20061 : 모노미노도미노 2 (23.08.10)

### DIFF
--- a/gibeom/23-08-10.py
+++ b/gibeom/23-08-10.py
@@ -1,0 +1,53 @@
+from sys import stdin
+from collections import deque
+
+
+def find_top(board, c):
+    for r in range(2, 6):
+        if board[r][c] == 1:
+            return r - 1
+    return 5
+
+
+def remove_full_col():
+    global res
+    for board in blue, green:
+        for r in range(2, 6):
+            if sum(board[r]) == 4:
+                del board[r]
+                board.appendleft([0] * 4)
+                res += 1
+
+
+def execute_special():
+    for board in blue, green:
+        while 1 in board[1]:
+            board.pop()
+            board.appendleft([0] * 4)
+
+
+blue = deque([deque([0] * 4) for _ in range(6)])
+green = deque([deque([0] * 4) for _ in range(6)])
+
+n = int(stdin.readline())
+res = 0
+for _ in range(n):
+    t, r, c = map(int, stdin.readline().split())
+    br, gr = find_top(blue, r), find_top(green, c)
+    if t == 2:
+        gr = min(gr, find_top(green, c + 1))
+        blue[br - 1][r], green[gr][c + 1] = 1, 1
+    elif t == 3:
+        br = min(br, find_top(blue, r + 1))
+        blue[br][r + 1], green[gr - 1][c] = 1, 1
+    blue[br][r], green[gr][c] = 1, 1
+    remove_full_col()
+    execute_special()
+
+print(res)
+print(sum(map(sum, blue)) + sum(map(sum, green)))
+
+##########################
+#    memory: 34332KB     #
+#    time:   112ms       #
+##########################


### PR DESCRIPTION
# 문제
#181 

## 해결 과정
``` python
from sys import stdin
from collections import deque


# 같은 열에 가장 앞에 존재하는 블록의 행을 찾아서 그 앞의 행을 리턴
def find_top(board, c):
    for r in range(2, 6): # 0, 1 행은 항상 블록이 없으므로 제외
        if board[r][c] == 1:
            return r - 1
    return 5


# 열이 꽉 찬 행은 삭제
def remove_full_col():
    global res
    for board in blue, green:
        for r in range(2, 6): # 0, 1 행은 항상 블록이 없으므로 제외
            if sum(board[r]) == 4: # 열이 꽉 찼을 때
                del board[r] # 해당 행 삭제
                board.appendleft([0] * 4) # 맨 앞에 행 추가
                res += 1 # 점수 +1


# 0, 1행에 블록이 존재하면 뒤부터 제거
def execute_special():
    for board in blue, green:
        while 1 in board[1]:
            board.pop()
            board.appendleft([0] * 4)


blue = deque([deque([0] * 4) for _ in range(6)]) # blue는 90도 돌려서 green과 같은 모양으로 시작
green = deque([deque([0] * 4) for _ in range(6)])

n = int(stdin.readline())
res = 0
for _ in range(n):
    t, r, c = map(int, stdin.readline().split())
    br, gr = find_top(blue, r), find_top(green, c) # 블록을 놓을 수 있는 행
    if t == 2:
        gr = min(gr, find_top(green, c + 1)) # green은 ㅁㅁ 모양으로 놓이므로 최소 행 계산
        blue[br - 1][r], green[gr][c + 1] = 1, 1
    elif t == 3:
        br = min(br, find_top(blue, r + 1)) # blue는 ㅁㅁ 모양으로 놓이므로 최소 행 계산
        blue[br][r + 1], green[gr - 1][c] = 1, 1
    blue[br][r], green[gr][c] = 1, 1
    remove_full_col()
    execute_special()

print(res)
print(sum(map(sum, blue)) + sum(map(sum, green)))
```

## 메모리, 시간
- 34332KB
- 112ms

